### PR TITLE
WS-856 Problematic urls

### DIFF
--- a/src/ApiClient/Client.php
+++ b/src/ApiClient/Client.php
@@ -168,4 +168,15 @@ class Client {
 		$response = $this->httpClient->get('account');
 		return $response;
 	}
+
+	/**
+	 * Get problematic urls
+	 *
+	 * @return PaginationIterator
+	 */
+	public function getProblematicUrls($scrapingJobId) {
+
+		$iterator = new PaginationIterator($this->httpClient, "scraping-job/{$scrapingJobId}/problematic-urls");
+		return $iterator;
+	}
 }

--- a/tests/test-sitemap-with-empty.json
+++ b/tests/test-sitemap-with-empty.json
@@ -1,0 +1,18 @@
+{
+    "_id":"webscraper-io-test-empty",
+    "startUrl":[
+        "https://webscraper.io/test-sites/e-commerce/static/computers/laptops",
+        "https://webscraper.io/test-sites/e-commerce/static/computers/tablets"
+    ],
+    "selectors":[
+        {
+            "id":"selector-test",
+            "type":"SelectorText",
+            "parentSelectors":["_root"],
+            "selector":"body:contains(\"Computers / Tablets\") .page-header",
+            "multiple":true,
+            "regex":"",
+            "delay":0
+        }
+    ]
+}


### PR DESCRIPTION
- `testGetProblematicUrls()` test will run around 6 min, because empty urls are retried 5 times
- Fixed `testGetScrapingJob`, need to expect `custom_id` key
- Fixed `testUpdateSitemap()`, now we don't allow to change `_id` for sitemap changed to us `startUrl` as modification for update.